### PR TITLE
fixed getting lookup index in a array with empty items

### DIFF
--- a/index.js
+++ b/index.js
@@ -168,7 +168,7 @@ function lookupIndex(collection, key) {
   });
 
   for (var i = 0; i < collection.length; i++) {
-    if (matches(collection[i], terms)) {
+    if (collection[i] && matches(collection[i], terms)) {
       return i;
     }
   }

--- a/test.js
+++ b/test.js
@@ -89,6 +89,13 @@ describe('update', function() {
       assert.deepEqual(upd.foo.baz, [1]);
     });
 
+    it('correctly operates with lookup key in a array with empty items', function() {
+      var obj = { foo: { bar: [{ a: 'a1' }, null, { a: 'a2' }] } };
+      var upd = update(obj, 'foo.bar.{a:a2}.a', 'a3');
+
+      assert.deepEqual(upd.foo.bar, [{ a: 'a1' }, null, { a: 'a3' }]);
+    });
+
     it('correctly assigns with lookup key', function() {
       var obj = { foo: { bar: false, baz: [{ a: 'a1' }, { a: 'a2' }] } };
       var upd = update(obj, {


### PR DESCRIPTION
- added additional check for getting lookup index, because
  there is the error `TypeError: Cannot read property 'foo' of null`
  for arrays with empty items
  eg. for `var a = [{ foo: 1 }]; a[10] = { foo: 10 }};`
- fixed tests